### PR TITLE
'go get' for installing executables is deprecated from Go 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```
-$ go get github.com/yusukebe/t/cmd/t
+$ go install github.com/yusukebe/t/cmd/t@latest
 ```
 
 ## Usage


### PR DESCRIPTION
References:
- https://golang.org/doc/go-get-install-deprecation (official)
- [Go1.17における go get の変更点 | フューチャー技術ブログ](https://future-architect.github.io/articles/20210818a/ "Go1.17における go get の変更点 | フューチャー技術ブログ")

```sh
/tmp $ go version
go version go1.17 linux/amd64
/tmp $ go get github.com/yusukebe/t/cmd/t
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```